### PR TITLE
Feat: add kirby blocks component

### DIFF
--- a/.changeset/ten-lamps-allow.md
+++ b/.changeset/ten-lamps-allow.md
@@ -1,0 +1,5 @@
+---
+'sveltekit-kql': minor
+---
+
+Feat: add kirby blocks component for rendering a list of blocks

--- a/src/lib/components/kirby-blocks/KirbyBlocks.svelte
+++ b/src/lib/components/kirby-blocks/KirbyBlocks.svelte
@@ -1,7 +1,7 @@
-<script
-	lang="ts"
-	generics="TBlocks extends Array<{type: string, isHidden: boolean, id: string, content: any}>"
->
+<!-- we use any here because we don't know the type of the blocks yet and the type will be too complex to define -->
+<script lang="ts" generics="TBlocks extends KirbyBlock<any>[]">
+	import type { KirbyBlock } from '$lib/types/blocks';
+
 	import { getBlocksContext } from './state.svelte';
 
 	const components = getBlocksContext();
@@ -18,6 +18,7 @@
 			Component not found: <span>{block.type}</span> in <span
 				>{JSON.stringify(components.getAllBlocks())}</span
 			>
+			Did you forget to add it to the blocks context?
 		</pre>
 	{/if}
 {/each}

--- a/src/lib/components/kirby-blocks/KirbyBlocks.svelte
+++ b/src/lib/components/kirby-blocks/KirbyBlocks.svelte
@@ -5,37 +5,131 @@
 	import { getBlocksContext } from './state.svelte';
 
 	const components = getBlocksContext();
-	type Props = { blocks: TBlocks };
+
+	type Props = {
+		/**
+		 * An array of blocks to render.
+		 */
+		blocks: TBlocks;
+		/** --- css props --- */
+
+		/** The padding of the error message */
+		'--error-padding'?: string;
+		/** The margin of the error message */
+		'--error-margin'?: string;
+		/** The border radius of the error message */
+		'--error-border-radius'?: string;
+		/** The border width of the error message */
+		'--error-border-width'?: string;
+		/** The border color of the error message */
+		'--error-border-color'?: string;
+		/** The background color of the error message */
+		'--error-background-color'?: string;
+		/** The text color of the error message */
+		'--error-text-color'?: string;
+	};
 	let { blocks }: Props = $props();
 </script>
 
-{#each blocks as block}
-	{#if block.type in components.blocks}
-		{@const Component = components.getBlock(block.type)}
-		<Component {block} />
-	{:else}
-		<pre class="error">
-			Component not found: <span>{block.type}</span> in <span
-				>{JSON.stringify(components.getAllBlocks())}</span
-			>
-			Did you forget to add it to the blocks context?
-		</pre>
-	{/if}
-{/each}
+{#if !components || !components.blocks}
+	<pre class="error">No blocks context found. Did you forget to set the blocks context?</pre>
+{:else}
+	{#each blocks as block}
+		{#if block.type in components.blocks}
+			{@const Component = components.getBlock(block.type)}
+			<Component {block} />
+		{:else}
+			<pre class="error">
+				Component not found: <span>{block.type}</span> in <span
+					>{JSON.stringify(components.getAllBlocks())}</span
+				>
+				Did you forget to add it to the blocks context?
+			</pre>
+		{/if}
+	{/each}
+{/if}
 
 <!-- 
 @component KirbyBlocks
 
 @description - A component that renders a list of blocks based on their type.
 
+@param blocks - An array of blocks to render.
 
-	
+@example
+```svelte
+<script>
+	import KirbyBlocks from 'sveltekit-kql/components';
+	import { setBlocksContext } from 'sveltekit-kql/components/';
+
+	//your components
+	import Heading from './Heading.svelte';
+	import Paragraph from './Paragraph.svelte';
+	import Image from './Image.svelte';
+
+	// Define the blocks context
+	setBlocksContext({
+		heading: Heading,
+		paragraph: Paragraph,
+		image: Image,
+	});
+</script>
+
+<KirbyBlocks {blocks} />
+
+```
+
+@css variables you can adjust:
+```css
+	--error-padding: 1rem;
+	--error-margin: 0.5rem;
+	--error-border-radius: 4px;
+	--error-border-width: 4px;
+	--error-border-color: #ff4444;
+	--error-background-color: #2a1717;
+	--error-text-color: #f8d7da;
+```
+
+@errors **The component will display an error message if:**
+	- The blocks context is not set.
+	- A block type is not found in the blocks context.
 	
 -->
 
 <style>
 	.error {
-		background-color: hsl(0, 0%, 20%);
-		color: aliceblue;
+		/* Container styling */
+		padding: var(--error-padding, 1rem);
+		border-radius: var(--error-border-radius, 4px);
+		border-left-width: var(--error-border-width, 4px);
+		border-left-color: var(--error-border-color, #ff4444);
+		border-left-style: solid;
+
+		/* Background and text */
+		background-color: var(--error-background-color, #2a1717);
+		color: var(--error-text-color, #f8d7da);
+		font-family:
+			system-ui,
+			-apple-system,
+			sans-serif;
+
+		/* Layout */
+		width: fit-content;
+		white-space-collapse: initial;
+		text-wrap: wrap;
+
+		/* Font settings */
+		font-size: 0.9rem;
+		line-height: 1.4;
+	}
+
+	.error span {
+		/* Technical details styling */
+		display: inline-block;
+		padding: 0.2rem 0.4rem;
+		background-color: hsla(0, 0%, 100%, 0.1);
+		border-radius: 3px;
+		font-family: monospace;
+		font-size: 0.85em;
 	}
 </style>

--- a/src/lib/components/kirby-blocks/KirbyBlocks.svelte
+++ b/src/lib/components/kirby-blocks/KirbyBlocks.svelte
@@ -1,0 +1,40 @@
+<script
+	lang="ts"
+	generics="TBlocks extends Array<{type: string, isHidden: boolean, id: string, content: any}>"
+>
+	import { getBlocksContext } from './state.svelte';
+
+	const components = getBlocksContext();
+	type Props = { blocks: TBlocks };
+	let { blocks }: Props = $props();
+</script>
+
+{#each blocks as block}
+	{#if block.type in components.blocks}
+		{@const Component = components.getBlock(block.type)}
+		<Component {block} />
+	{:else}
+		<pre class="error">
+			Component not found: <span>{block.type}</span> in <span
+				>{JSON.stringify(components.getAllBlocks())}</span
+			>
+		</pre>
+	{/if}
+{/each}
+
+<!-- 
+@component KirbyBlocks
+
+@description - A component that renders a list of blocks based on their type.
+
+
+	
+	
+-->
+
+<style>
+	.error {
+		background-color: hsl(0, 0%, 20%);
+		color: aliceblue;
+	}
+</style>

--- a/src/lib/components/kirby-blocks/state.svelte.ts
+++ b/src/lib/components/kirby-blocks/state.svelte.ts
@@ -1,13 +1,14 @@
 import { getContext, setContext, type Component } from 'svelte';
+import type { BlocksMap, KirbyBlockType, KirbyComponentProps } from '$lib/types/blocks';
 
 export class KirbyBlocks {
-	blocks: Record<string, Component> = $state({});
+	blocks: BlocksMap = $state({});
 
-	constructor(blocks: Record<string, Component>) {
+	constructor(blocks: BlocksMap) {
 		this.blocks = blocks;
 	}
 
-	setBlocks(blocks: Record<string, Component>) {
+	setBlocks(blocks: BlocksMap) {
 		this.blocks = blocks;
 	}
 
@@ -16,14 +17,14 @@ export class KirbyBlocks {
 		return Object.keys(this.blocks);
 	}
 
-	getBlock(name: string) {
+	getBlock<T extends KirbyBlockType>(name: T): Component<KirbyComponentProps<T>> | undefined {
 		return this.blocks[name];
 	}
 }
 
 const KEY = Symbol('kirby-blocks' as const);
 
-export function setBlocksContext(blocks: Record<string, Component>) {
+export function setBlocksContext(blocks: BlocksMap) {
 	return setContext(KEY, new KirbyBlocks(blocks));
 }
 

--- a/src/lib/components/kirby-blocks/state.svelte.ts
+++ b/src/lib/components/kirby-blocks/state.svelte.ts
@@ -1,0 +1,32 @@
+import { getContext, setContext, type Component } from 'svelte';
+
+export class KirbyBlocks {
+	blocks: Record<string, Component> = $state({});
+
+	constructor(blocks: Record<string, Component>) {
+		this.blocks = blocks;
+	}
+
+	setBlocks(blocks: Record<string, Component>) {
+		this.blocks = blocks;
+	}
+
+	getAllBlocks() {
+		// get all the keys together with the name of the component
+		return Object.keys(this.blocks);
+	}
+
+	getBlock(name: string) {
+		return this.blocks[name];
+	}
+}
+
+const KEY = Symbol('kirby-blocks' as const);
+
+export function setBlocksContext(blocks: Record<string, Component>) {
+	return setContext(KEY, new KirbyBlocks(blocks));
+}
+
+export function getBlocksContext() {
+	return getContext<ReturnType<typeof setBlocksContext>>(KEY);
+}

--- a/src/lib/types/block.ts
+++ b/src/lib/types/block.ts
@@ -1,4 +1,5 @@
 import type { AllowedMethodsForSiblings } from './allowedMethods';
+import type { KirbyBlockType } from './blocks';
 import type { Collection } from './collection';
 import type { Content } from './content';
 import type { Field } from './field';
@@ -9,7 +10,7 @@ export interface Block extends AllowedMethodsForSiblings {
 		id: () => string;
 		isEmpty: () => boolean;
 		isHidden: () => boolean;
-		type: () => string;
+		type: () => KirbyBlockType;
 	};
 
 	content: () => Content;
@@ -20,7 +21,7 @@ export interface Block extends AllowedMethodsForSiblings {
 	toField: () => Field;
 	toHtml: () => string;
 	parent: () => Content;
-	type: () => string;
+	type: () => KirbyBlockType;
 }
 
 export interface Blocks extends Collection<Block> {

--- a/src/lib/types/blocks/index.ts
+++ b/src/lib/types/blocks/index.ts
@@ -1,0 +1,62 @@
+/**
+ * @fileoverview Block types
+ * these types were inspired (and mostly copied from) [these types](https://github.com/johannschopplich/kirby-types/blob/main/src/blocks.d.ts) from Johann Schopplich
+ *
+ * this file defines the block types from kirby with their content properties. these can be used in order to make components.
+ */
+
+/**
+ * Default block types with their content properties
+ *
+ * @todo (1.0 / 1.x / 2.0)make users able to add their own block types using the KQL namespace
+ */
+interface KirbyDefaultBlocks {
+	code: {
+		code: string;
+		language: string;
+	};
+	gallery: { images: string[] };
+
+	heading: {
+		level: string;
+		text: string;
+	};
+
+	text: {
+		text: string;
+	};
+
+	quote: {
+		text: string;
+		citation: string;
+	};
+
+	list: { text: string };
+	markdown: { text: string };
+
+	image: {
+		alt: string;
+		caption: string;
+		crop: boolean;
+		image: string[] | `file://${string}`[];
+		link: string;
+		location: string;
+		ratio: string;
+		src: string;
+	};
+
+	video: { url: string; caption: string };
+}
+
+/**
+ * Base block type
+ *
+ * @param TType - Type of the block
+ * @param TContent - Type of the content
+ */
+export interface KirbyBlock<TType extends keyof KirbyDefaultBlocks> {
+	id: string;
+	type: TType;
+	isHidden: boolean;
+	content: KirbyDefaultBlocks[TType];
+}

--- a/src/lib/types/blocks/index.ts
+++ b/src/lib/types/blocks/index.ts
@@ -5,12 +5,14 @@
  * this file defines the block types from kirby with their content properties. these can be used in order to make components.
  */
 
+import type { Component } from 'svelte';
+
 /**
  * Default block types with their content properties
  *
  * @todo (1.0 / 1.x / 2.0)make users able to add their own block types using the KQL namespace
  */
-interface KirbyDefaultBlocks {
+export interface KirbyDefaultBlocks {
 	code: {
 		code: string;
 		language: string;
@@ -38,7 +40,7 @@ interface KirbyDefaultBlocks {
 		alt: string;
 		caption: string;
 		crop: boolean;
-		image: string[] | `file://${string}`[];
+		image: `file://${string}`[];
 		link: string;
 		location: string;
 		ratio: string;
@@ -52,11 +54,23 @@ interface KirbyDefaultBlocks {
  * Base block type
  *
  * @param TType - Type of the block
- * @param TContent - Type of the content
  */
-export interface KirbyBlock<TType extends keyof KirbyDefaultBlocks> {
+export interface KirbyBlock<TType extends KirbyBlockType> {
 	id: string;
 	type: TType;
 	isHidden: boolean;
 	content: KirbyDefaultBlocks[TType];
 }
+type Prettify<T> = { [P in keyof T]: T[P] };
+// create a type that is a union of all the keys of the default blocks
+export type KirbyBlockType = Prettify<keyof KirbyDefaultBlocks>;
+
+export type BlocksMap = Partial<{
+	[TType in KirbyBlockType]: Component<KirbyComponentProps<TType>>;
+}>;
+
+export type KirbyComponentProps<TBlockType extends KirbyBlockType> = {
+	block: KirbyBlock<TBlockType>;
+};
+
+export type * from '.';

--- a/src/lib/types/content.ts
+++ b/src/lib/types/content.ts
@@ -1,9 +1,8 @@
+import type { KirbyBlock, KirbyBlockType } from './blocks';
 import type { Field } from './field';
 
 export type Content = {
-	__default: {
-		[key: string]: string;
-	};
+	__default: KirbyBlock<KirbyBlockType>;
 	__extra: Field;
 	data: Record<string, Field>;
 	fields: () => {


### PR DESCRIPTION
adds a kirby blocks component for rendering a list of blocks, while providing typesafety. it can be used in layouts or when getting every block on a page. and rendering them.